### PR TITLE
Adding support for DashScopeEmbeddings to handle Aliyun embedding models

### DIFF
--- a/backend/config/init_config.yaml.copy
+++ b/backend/config/init_config.yaml.copy
@@ -18,7 +18,7 @@ LLM_MODELS:
 EMBEDDING_MODELS:
   # OpenAI Embedding model
   - name: "text-embedding-ada-002"          # Model name
-    deployment_type: "cloud"                # Deployment type: cloud or local  
+    deployment_type: "cloud"                # Deployment type: cloud or cloud-aliyun or local
     category: "embedding"                   # Model category
     api_base: "https://api.openai.com/v1"   # API base URL
     api_key: "your-openai-api-key"          # Replace with your actual API key

--- a/backend/llm_model/embeddings.py
+++ b/backend/llm_model/embeddings.py
@@ -2,6 +2,7 @@ import numpy as np
 from typing import List, Union, Optional, Dict
 from langchain_openai import OpenAIEmbeddings
 from langchain_community.embeddings.huggingface import HuggingFaceEmbeddings
+from langchain_community.embeddings import DashScopeEmbeddings
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
 from models import LLMModel
@@ -92,6 +93,13 @@ class EmbeddingManager:
                     model=model_config['name'],
                     openai_api_key=model_config['api_key'],
                     openai_api_base=model_config['api_base']
+                )
+            elif model_config["deployment_type"] == "cloud-aliyun":
+                # Cloud model (Aliyun)
+                # Ref: https://help.aliyun.com/zh/model-studio/use-bailian-in-langchain
+                embedding = DashScopeEmbeddings(
+                    model=model_config["name"],
+                    dashscope_api_key=model_config["api_key"],
                 )
             else:
                 import torch


### PR DESCRIPTION
This fix ensures proper initialization of Aliyun's text embedding models via `DashScopeEmbeddings`, as required by [Aliyun's official documentation](https://help.aliyun.com/zh/model-studio/use-bailian-in-langchain).

Addresses the embedding initialization issue reported in: https://github.com/weAIDB/CrackSQL/issues/8#issuecomment-2919648234

Further testing may be needed by maintainers to verify full compatibility.