### PR TITLE
Fix database config argument names in translate.py

### DIFF
--- a/backend/translate.py
+++ b/backend/translate.py
@@ -972,9 +972,9 @@ def main():
             tgt_db_config = {
                 "host": args.host,
                 "port": args.port,
-                "user": args.username,
+                "user": args.user,
                 "password": args.password,
-                "db_name": args.database
+                "db_name": args.db_name
             }
 
         vector_config = None


### PR DESCRIPTION
Fixes database configuration in `./backend/translate.py` by correcting argument names.

https://github.com/weAIDB/CrackSQL/blob/4fd55d39ed3ba7730f3617cf39ab2b312ed000ae/backend/translate.py#L972-L978

Now uses `args.user` for the database user and `args.db_name` for the database name to match the parser definitions.

This resolves https://github.com/weAIDB/CrackSQL/issues/5 :

![snapshot of error](https://github.com/user-attachments/assets/a7bcbb33-454c-472c-87ff-552b6b04eccb)
