### PR TITLE
Optimize the batching logic of the embeddings

### DIFF
--- a/backend/llm_model/embeddings.py
+++ b/backend/llm_model/embeddings.py
@@ -8,6 +8,19 @@ from models import LLMModel
 from config.db_config import db, db_session_manager
 from config.logging_config import logger
 
+# OpenAI / Azure-OpenAI allows up to 300 000 tokens per embedding request.
+# Leave some headroom to reduce the chance of repeated retries at the limit.
+_MAX_TOKENS_PER_REQ = 290_000
+
+
+def _estimate_tokens(text: str) -> int:
+    """
+    Roughly estimate how many tokens `text` consumes.
+    For English models, on average 1 token ≈ 4 characters; for Chinese, 1 token ≈ 1.3–2 characters.
+    We use a compromise value of 3.5 characters per token to ensure a safer upper-bound estimate.
+    """
+    return max(1, int(len(text) / 3.5))
+
 
 class EmbeddingManager:
     """Embedding Manager"""
@@ -144,9 +157,31 @@ async def _get_embeddings_with_context(text: Union[str, List[str]], model_name: 
         if isinstance(text, str):
             embedding = await embedding_model.aembed_query(text[:8192])
         else:
-            text = [t[:8192] for t in text]
-            embedding = await embedding_model.aembed_documents(text)
+            # First, trim each text to 8 192 characters
+            texts = [t[:8192] for t in text]
+
+            # —— Batching logic —— #
+            batches, cur_batch, cur_tokens = [], [], 0
+            for t in texts:
+                tok = _estimate_tokens(t)
+                # If adding `t` would exceed the per-request token limit, finalize the current batch
+                if cur_batch and cur_tokens + tok > _MAX_TOKENS_PER_REQ:
+                    batches.append(cur_batch)
+                    cur_batch, cur_tokens = [], 0
+                cur_batch.append(t)
+                cur_tokens += tok
+            if cur_batch:           # Process the last batch
+                batches.append(cur_batch)
+
+            # Send requests sequentially to preserve output order
+            embedding = []
+            for bt in batches:
+                bt_emb = await embedding_model.aembed_documents(bt)
+                embedding.extend(bt_emb)
+
         return np.array(embedding)
+
     except Exception as e:
         logger.error(f"Failed to generate Embedding: {str(e)}")
         raise
+


### PR DESCRIPTION
Trying to fix the error "beyond max_tokens_per_request" as follows:

When utilizing the text-embedding-ada-002 model as the embedding model, the following issues were encountered during the initialization of the knowledge base:  
```
Failed to generate Embedding: Error code: 400 - {'error': {'message': 'Requested 453357 tokens, max 300000 tokens per request', 'type': 'max_tokens_per_request', 'param': None, 'code': 'max_tokens_per_request'}}
```
This occurred because all three embedding models provided by OpenAI (Text-Embedding-3-small, Text-Embedding-3-large, and Text-Embedding-Ada-002) are subject to two types of limitations: an MAX INPUT limit of 8192 tokens and a max_tokens_per_request limit of 300,000 tokens. When embedding the knowledge base, the total number of tokens exceeded the latter limit, resulting in the aforementioned error.

This error was not observed during the previous development phase, likely due to the use of alternative embedding models.

The solution implemented involves estimating the total token consumption and processing the data in batches when the max_tokens_per_request limit is exceeded.

Although this issue may not arise when using other embedding models, the proposed solution does not interfere with the operation of other models. Therefore, no logical distinctions based on the embedding models were introduced.